### PR TITLE
Update UrlTypeVFS.java avoid warning altogether

### DIFF
--- a/src/main/java/org/reflections/vfs/UrlTypeVFS.java
+++ b/src/main/java/org/reflections/vfs/UrlTypeVFS.java
@@ -38,13 +38,11 @@ public class UrlTypeVFS implements UrlType {
             URL adaptedUrl = adaptURL(url);
             return new ZipDir(new JarFile(adaptedUrl.getFile()));
         } catch (Exception e) {
-            if (Reflections.log != null) {
-                Reflections.log.warn("Could not get URL", e);
-            }
             try {
                 return new ZipDir(new JarFile(url.getFile()));
             } catch (IOException e1) {
                 if (Reflections.log != null) {
+                    Reflections.log.warn("Could not get URL", e);
                     Reflections.log.warn("Could not get URL", e1);
                 }
             }


### PR DESCRIPTION
if "return new ZipDir(new JarFile(url.getFile()));" did not throw an exception, there shouldn't be a warning.
